### PR TITLE
Add custom header support to SUBSCRIBE frame.

### DIFF
--- a/krossbow-stomp-core/api/krossbow-stomp-core.api
+++ b/krossbow-stomp-core/api/krossbow-stomp-core.api
@@ -968,8 +968,8 @@ public final class org/hildan/krossbow/stomp/headers/StompSendHeaders : org/hild
 }
 
 public final class org/hildan/krossbow/stomp/headers/StompSubscribeHeaders : org/hildan/krossbow/stomp/headers/StompHeaders {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lorg/hildan/krossbow/stomp/headers/AckMode;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lorg/hildan/krossbow/stomp/headers/AckMode;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lorg/hildan/krossbow/stomp/headers/AckMode;Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lorg/hildan/krossbow/stomp/headers/AckMode;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Lorg/hildan/krossbow/stomp/headers/StompHeaders;)V
 	public fun clear ()V
 	public final fun containsKey (Ljava/lang/Object;)Z

--- a/krossbow-stomp-core/src/commonMain/kotlin/org/hildan/krossbow/stomp/headers/StompHeaders.kt
+++ b/krossbow-stomp-core/src/commonMain/kotlin/org/hildan/krossbow/stomp/headers/StompHeaders.kt
@@ -136,12 +136,14 @@ data class StompSubscribeHeaders(private val rawHeaders: StompHeaders) : StompHe
         id: String? = null, // not optional, but this allows generating it in subscription flows
         ack: AckMode = AckMode.AUTO,
         receipt: String? = null,
-    ) : this(
+        customHeaders: Map<String, String> = emptyMap(),
+        ) : this(
         headersOf(
             DESTINATION to destination,
             ID to id,
             ACK to ack.headerValue,
             RECEIPT to receipt,
+            customHeaders = customHeaders
         )
     )
 }

--- a/krossbow-stomp-core/src/commonTest/kotlin/org/hildan/krossbow/stomp/frame/StompCodecTest.kt
+++ b/krossbow-stomp-core/src/commonTest/kotlin/org/hildan/krossbow/stomp/frame/StompCodecTest.kt
@@ -1,8 +1,6 @@
 package org.hildan.krossbow.stomp.frame
 
-import org.hildan.krossbow.stomp.headers.StompConnectHeaders
-import org.hildan.krossbow.stomp.headers.StompMessageHeaders
-import org.hildan.krossbow.stomp.headers.StompSendHeaders
+import org.hildan.krossbow.stomp.headers.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -93,6 +91,30 @@ class StompCodecTest {
 
         val headers = StompConnectHeaders(host = "some.host", acceptVersion = listOf("1.0", "1.1", "1.2"))
         val frame = StompFrame.Connect(headers)
+        assertEncodingDecoding(frameText, frame, frame)
+    }
+
+    @Test
+    fun subscribe_custom_headers() {
+        val frameText = """
+            SUBSCRIBE
+            destination:/topic/dest
+            id:0
+            ack:auto
+            receipt:message-1234
+            Authorization:Bearer -jwt-
+            
+            $nullChar
+        """.trimIndent()
+
+        val headers = StompSubscribeHeaders(
+                destination = "/topic/dest",
+                id = "0",
+                ack = AckMode.AUTO,
+                receipt = "message-1234",
+                customHeaders = mapOf("Authorization" to "Bearer -jwt-")
+        )
+        val frame = StompFrame.Subscribe(headers)
         assertEncodingDecoding(frameText, frame, frame)
     }
 


### PR DESCRIPTION
* Allow custom headers when subscribing to a specific topic.

According to the STOMP documentation (https://stomp.github.io/stomp-specification-1.2.html#SUBSCRIBE), STOMP servers MAY support additional headers.

I haven´t opened an issue because this is such a small feature request. If something is missing please let me know.