### PR TITLE
Add iOS ARM64 Simulator Support (M1)

### DIFF
--- a/buildSrc/src/main/kotlin/SourceSets.kt
+++ b/buildSrc/src/main/kotlin/SourceSets.kt
@@ -7,6 +7,8 @@ import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
 
 fun KotlinMultiplatformExtension.setupNativeTargets() {
     ios()
+    iosSimulatorArm64()
+
     tvos()
 
     // watchos() shortcut cannot be used because okio is missing watchosX64()
@@ -43,6 +45,13 @@ fun NamedDomainObjectContainer<KotlinSourceSet>.setupNativeSourceSets() {
     }
     val iosTest by getting {
         dependsOn(nativeDarwinTest)
+    }
+
+    val iosSimulatorArm64Main by getting {
+        dependsOn(iosMain)
+    }
+    val iosSimulatorArm64Test by getting {
+        dependsOn(iosTest)
     }
 
     val watchosX86Main by getting {

--- a/krossbow-stomp-kxserialization/build.gradle.kts
+++ b/krossbow-stomp-kxserialization/build.gradle.kts
@@ -12,6 +12,7 @@ kotlin {
         browser()
     }
     ios()
+    iosSimulatorArm64()
 
     sourceSets {
         all {


### PR DESCRIPTION
I was unable to use krossbow for a new project at work where our app does support developing on an M1 Mac, which requires building for ARM64 iOS Simulator.

Turns out, there wasn't much missing to support it :)

Tested by successfully building the project with `./gradlew publishToMavenLocal` and then using the local maven repo on my project to test the app on Simulator.


