### PR TITLE
Mark NO_HEART_BEATS immutable

### DIFF
--- a/krossbow-stomp-core/src/commonMain/kotlin/org/hildan/krossbow/stomp/heartbeats/HeartBeats.kt
+++ b/krossbow-stomp-core/src/commonMain/kotlin/org/hildan/krossbow/stomp/heartbeats/HeartBeats.kt
@@ -1,8 +1,10 @@
 package org.hildan.krossbow.stomp.heartbeats
 
 import org.hildan.krossbow.stomp.config.HeartBeat
+import kotlin.native.concurrent.SharedImmutable
 import kotlin.time.Duration
 
+@SharedImmutable
 internal val NO_HEART_BEATS = HeartBeat(Duration.ZERO, Duration.ZERO)
 
 internal fun HeartBeat.negotiated(serverHeartBeats: HeartBeat?): HeartBeat = HeartBeat(


### PR DESCRIPTION
I was running into an exception at runtime on iOS, right after completing the handshake, while instantiating `BaseStompSession`: `kotlin.native.IncorrectDereferenceException: Trying to access top level value not marked as @ThreadLocal or @SharedImmutable from non-main thread`.

After some digging, it turned out this heartbeat constant was the culprit.

This fix was tested successfully by running `./gradlew publishToMavenLocal` and then running my test project locally. The stomp session was established successfully afterwards, without any exception thrown.