### PR TITLE
Fix memory crash on iOS with old memory model

### DIFF
--- a/krossbow-websocket-core/src/nativeDarwinMain/kotlin/org/hildan/krossbow/websocket/darwin/DarwinWebSocketClient.kt
+++ b/krossbow-websocket-core/src/nativeDarwinMain/kotlin/org/hildan/krossbow/websocket/darwin/DarwinWebSocketClient.kt
@@ -3,14 +3,12 @@
 package org.hildan.krossbow.websocket.darwin
 
 import kotlinx.cinterop.*
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.BUFFERED
 import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.suspendCancellableCoroutine
-import kotlinx.coroutines.withContext
 import org.hildan.krossbow.websocket.*
 import platform.Foundation.*
 import platform.darwin.NSObject
@@ -25,13 +23,6 @@ import kotlin.coroutines.resumeWithException
 private const val ERROR_CODE_SOCKET_NOT_CONNECTED = 57
 
 /**
- * Signature for a callback to be passed around to initialize a [WebSocketConnectionWithPing] from the given parameters.
- * This is used to either build a [IosWebSocketConnection] or [MainThreadedIosWebSocketConnection],
- * based on the memory model in use at runtime.
- */
-private typealias WebSocketConnectionWithPingFactory = (String, Flow<WebSocketFrame>, NSURLSessionWebSocketTask) -> WebSocketConnectionWithPing
-
-/**
  * An implementation of [WebSocketClient] using darwin's native [NSURLSessionWebSocketTask].
  * This is only available is iOS 13.0+, tvOS 13.0+, watchOS 6.0+, macOS 10.15+
  * (see [documentation](https://developer.apple.com/documentation/foundation/urlsessionwebsockettask))
@@ -44,38 +35,15 @@ class DarwinWebSocketClient(
     private val maximumMessageSize: Long? = null,
 ) : WebSocketClient {
 
-    @Suppress("NAME_SHADOWING")
-    @OptIn(ExperimentalStdlibApi::class)
-    override suspend fun connect(url: String): WebSocketConnectionWithPing = if (isExperimentalMM()) {
-        makeWebSocketConnectionWithPing(
-            url = url,
-            delegateOnMainQueue = false,
-        ) { url, incomingFrames, webSocketTask ->
-            IosWebSocketConnection(url, incomingFrames, webSocketTask)
-        }
-    } else {
-        withContext(Dispatchers.Main) {
-            makeWebSocketConnectionWithPing(
-                url = url,
-                delegateOnMainQueue = false,
-            ) { url, incomingFrames, webSocketTask ->
-                MainThreadedIosWebSocketConnection(url, incomingFrames, webSocketTask)
-            }
-        }
-    }
-
-    private suspend fun makeWebSocketConnectionWithPing(
-        url: String,
-        delegateOnMainQueue: Boolean,
-        makeConnection: WebSocketConnectionWithPingFactory,
-    ): WebSocketConnectionWithPing {
+    override suspend fun connect(url: String): WebSocketConnectionWithPing {
         val socketEndpoint = NSURL.URLWithString(url)!!
+
         return suspendCancellableCoroutine { cont ->
             val incomingFrames: Channel<WebSocketFrame> = Channel(BUFFERED)
             val urlSession = NSURLSession.sessionWithConfiguration(
                 configuration = sessionConfig,
-                delegate = IosWebSocketListener(url, cont, incomingFrames, makeConnection),
-                delegateQueue = if (delegateOnMainQueue) NSOperationQueue.mainQueue() else NSOperationQueue.currentQueue()
+                delegate = IosWebSocketListener(url, cont, incomingFrames),
+                delegateQueue = NSOperationQueue.currentQueue()
             )
             val webSocket = urlSession.webSocketTaskWithURL(socketEndpoint)
             maximumMessageSize?.let { webSocket.setMaximumMessageSize(it.convert()) }
@@ -90,13 +58,12 @@ class DarwinWebSocketClient(
 
 private class IosWebSocketListener(
     private val url: String,
-    private var connectionContinuation: Continuation<WebSocketConnectionWithPing>?,
+    private var connectionContinuation: Continuation<IosWebSocketConnection>?,
     private val incomingFrames: Channel<WebSocketFrame>,
-    private val makeConnection: WebSocketConnectionWithPingFactory,
 ) : NSObject(), NSURLSessionWebSocketDelegateProtocol {
     private var isConnecting = true
 
-    private inline fun completeConnection(resume: Continuation<WebSocketConnectionWithPing>.() -> Unit) {
+    private inline fun completeConnection(resume: Continuation<IosWebSocketConnection>.() -> Unit) {
         val cont = connectionContinuation ?: error("web socket connection continuation already consumed")
         connectionContinuation = null // avoid leaking the continuation
         isConnecting = false
@@ -105,7 +72,7 @@ private class IosWebSocketListener(
 
     override fun URLSession(session: NSURLSession, webSocketTask: NSURLSessionWebSocketTask, didOpenWithProtocol: String?) {
         completeConnection {
-            resume(makeConnection(url, incomingFrames.receiveAsFlow(), webSocketTask))
+            resume(IosWebSocketConnection(url, incomingFrames.receiveAsFlow(), webSocketTask))
         }
     }
 
@@ -161,8 +128,7 @@ private class IosWebSocketListener(
         incomingFrames.close()
     }
 }
-
-private open class IosWebSocketConnection(
+private class IosWebSocketConnection(
     override val url: String,
     override val incomingFrames: Flow<WebSocketFrame>,
     private val webSocket: NSURLSessionWebSocketTask,
@@ -179,7 +145,7 @@ private open class IosWebSocketConnection(
         sendMessage(NSURLSessionWebSocketMessage(frameData.toNSData()))
     }
 
-    internal open suspend fun sendMessage(message: NSURLSessionWebSocketMessage) {
+    private fun sendMessage(message: NSURLSessionWebSocketMessage) {
         // We can't rely on the callback for suspension because it is sometimes not called by iOS
         // (for instance when the web socket is closing at the same time).
         // To avoid suspending forever in those cases, we just never suspend.
@@ -200,29 +166,6 @@ private open class IosWebSocketConnection(
 
     override suspend fun close(code: Int, reason: String?) {
         webSocket.cancelWithCloseCode(code.convert(), reason?.encodeToNSData())
-    }
-}
-
-/**
- * [MainThreadedIosWebSocketConnection] is a variant of [IosWebSocketConnection] that processes
- * all its callbacks on the same thread, which fixes memory access issues with the old memory model.
- */
-private class MainThreadedIosWebSocketConnection(
-    url: String,
-    incomingFrames: Flow<WebSocketFrame>,
-    webSocket: NSURLSessionWebSocketTask
-) : IosWebSocketConnection(url, incomingFrames, webSocket) {
-
-    override suspend fun sendMessage(message: NSURLSessionWebSocketMessage) = withContext(Dispatchers.Main) {
-        super.sendMessage(message)
-    }
-
-    override suspend fun sendPing(frameData: ByteArray) = withContext(Dispatchers.Main) {
-        super.sendPing(frameData)
-    }
-
-    override suspend fun close(code: Int, reason: String?) = withContext(Dispatchers.Main) {
-        super.close(code, reason)
     }
 }
 


### PR DESCRIPTION
This fixes a crash in `DarwinWebSocketClient` when using the old memory model.

The project I'm working on is still using the old memory model and I kept crashing upon initiating the web socket connection.

The crash is related to memory corruption when accessing the `NSURLSessionWebSocketTask` in any of the callbacks from `NSURLSessionDelegate`, which makes me think maybe we should be freezing it, or always access it from the same thread?

I couldn’t figure out how to fix the root cause other than enforcing access to it from the same thread, which this achieves by always using `withContext(Dispatchers.Main)`.

The amount of processing done seems pretty light so it shouldn’t be too problematic to have it happen on the main thread?

FWIW, the crash doesn't happen with the new memory model.

We've been using this for several weeks on my project with no issues. Just thought it would be nice to contribute this fix back, even if it's not the most elegant way to fix it.

Stacktrace:
```
Uncaught Kotlin exception: kotlin.native.IncorrectDereferenceException: illegal attempt to access non-shared <object>@b00988 from other thread
    at 0   IosApp                        0x106cdfbff        kfun:kotlin.Throwable#<init>(kotlin.String?){} + 95 
    at 1   IosApp                        0x106cd9213        kfun:kotlin.Exception#<init>(kotlin.String?){} + 91 
    at 2   IosApp                        0x106cd93c7        kfun:kotlin.RuntimeException#<init>(kotlin.String?){} + 91 
    at 3   IosApp                        0x106cec04b        kfun:kotlin.native.IncorrectDereferenceException#<init>(kotlin.String){} + 91 
    at 4   IosApp                        0x106cef283        ThrowIllegalObjectSharingException + 423 
    at 5   IosApp                        0x106e46bef        _ZN12_GLOBAL__N_128throwIllegalSharingExceptionEP9ObjHeader + 27 
    at 6   IosApp                        0x106e481c7        _ZN12_GLOBAL__N_136terminateWithIllegalSharingExceptionEP9ObjHeader + 11 
    at 7   IosApp                        0x106e51c73        _ZNK16KRefSharedHolder3refIL11ErrorPolicy3EEEP9ObjHeaderv + 111 
    at 8   IosApp                        0x106cbe0ff        _ZL39Kotlin_Interop_unwrapKotlinObjectHolderP11objc_object + 47 
    at 9   IosApp                        0x1071f9593        _6f72672e68696c64616e2e6b726f7373626f773a6b726f7373626f772d776562736f636b65742d636f7265_knbridge18 + 163 
    at 10  libdispatch.dylib                   0x104668803        _dispatch_call_block_and_release + 31 
    at 11  libdispatch.dylib                   0x10466a3a7        _dispatch_client_callout + 19 
    at 12  libdispatch.dylib                   0x104673777        _dispatch_lane_serial_drain + 979 
    at 13  libdispatch.dylib                   0x104674813        _dispatch_lane_invoke + 491 
    at 14  libdispatch.dylib                   0x1046840c7        _dispatch_workloop_worker_thread + 1231 
    at 15  libsystem_pthread.dylib             0x10416bf83        _pthread_wqthread + 287 
    at 16  libsystem_pthread.dylib             0x104173a9b        start_wqthread + 7 
```