### PR TITLE
Reviewed headers logic and documentation

### DIFF
--- a/krossbow-stomp-core/src/commonMain/kotlin/org/hildan/krossbow/stomp/headers/HeaderDelegates.kt
+++ b/krossbow-stomp-core/src/commonMain/kotlin/org/hildan/krossbow/stomp/headers/HeaderDelegates.kt
@@ -4,21 +4,53 @@ import kotlin.properties.ReadOnlyProperty
 import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.KProperty
 
+/**
+ * Delegated properties for StompHeaders
+ *
+ * The functions here assist in creating a 'HeaderDelegate' or a 'MutableHeaderDelegate'. These delegates are useful
+ * in defining properties for 'StompHeaders' objects ('MutableMap<String, String>' values). Essentially, they
+ * encapsulate these properties with an option of 'customName', and also apply transformation operations during
+ * 'getValue' and 'setValue' calls.
+ *
+ * These components enable the creation of varied delegates that can apply constraints (either mandatory or optional)
+ * and transformations (like converting a header string value to a different type or providing a default value)
+ * on these header values.
+ */
+
+/**
+ * Mandatory header for type String without transformations
+ */
 internal fun header(customKey: String? = null): HeaderDelegate<String> = header(customKey) { it }
 
+/**
+ * Optional header for type String without transformations
+ */
 internal fun optionalHeader(customKey: String? = null): HeaderDelegate<String?> = optionalHeader(customKey) { it }
 
+/**
+ * Optional header with transformed getValue to T
+ */
 internal inline fun <T> optionalHeader(
     customKey: String? = null,
     crossinline transform: (String) -> T,
 ): HeaderDelegate<T?> = optionalHeader(customKey, null, transform)
 
+/**
+ * Mutable Optional header with default value of type String without transformation
+ */
 internal fun mutableOptionalHeader(customKey: String? = null, default: String? = null): MutableHeaderDelegate<String?> =
     mutableOptionalHeader(customKey, default, { it }, { it })
 
+/**
+ * Mutable Optional header with default value of type Int
+ */
 internal fun mutableOptionalIntHeader(customKey: String? = null, default: Int? = null): MutableHeaderDelegate<Int?> =
     mutableOptionalHeader(customKey, default, { it.toInt() }, { it.toString() })
 
+
+/**
+ * Mandatory header with generic transform
+ */
 internal inline fun <T> header(customKey: String? = null, crossinline transform: (String) -> T): HeaderDelegate<T> =
     HeaderDelegate(customKey) { value, key ->
         value?.let(transform) ?: throw IllegalStateException("missing required header '$key'")
@@ -30,6 +62,9 @@ internal inline fun <T> optionalHeader(
     crossinline transform: (String) -> T,
 ): HeaderDelegate<T> = HeaderDelegate(customKey) { value, _ -> value?.let(transform) ?: default }
 
+/**
+ * Generic mutable optional header with a default value (can be null).
+ */
 internal inline fun <T> mutableOptionalHeader(
     customKey: String? = null,
     default: T,

--- a/krossbow-stomp-core/src/commonMain/kotlin/org/hildan/krossbow/stomp/headers/StompHeaders.kt
+++ b/krossbow-stomp-core/src/commonMain/kotlin/org/hildan/krossbow/stomp/headers/StompHeaders.kt
@@ -20,6 +20,7 @@ import org.hildan.krossbow.stomp.headers.HeaderNames.SESSION
 import org.hildan.krossbow.stomp.headers.HeaderNames.SUBSCRIPTION
 import org.hildan.krossbow.stomp.headers.HeaderNames.TRANSACTION
 import org.hildan.krossbow.stomp.headers.HeaderNames.VERSION
+import org.hildan.krossbow.stomp.utils.generateUuid
 import org.hildan.krossbow.stomp.version.*
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -135,7 +136,7 @@ data class StompSubscribeHeaders(private val rawHeaders: StompHeaders) : StompHe
 
     constructor(
         destination: String,
-        id: String? = null, // not optional, but this allows generating it in subscription flows
+        id: String = generateUuid(),
         ack: AckMode = AckMode.AUTO,
         receipt: String? = null,
         customHeaders: Map<String, String> = emptyMap(),

--- a/krossbow-websocket-core/src/commonMain/kotlin/org/hildan/krossbow/websocket/WebSocketConnection.kt
+++ b/krossbow-websocket-core/src/commonMain/kotlin/org/hildan/krossbow/websocket/WebSocketConnection.kt
@@ -22,7 +22,7 @@ interface WebSocketConnection {
         get() = url.substringAfter("://").substringBefore("/").substringBefore(":")
 
     /**
-     * The web socket subprotocol spoken over this [WebSocketConnection], or null is no specific protocol was agreed
+     * The web socket subprotocol spoken over this [WebSocketConnection], or null if no specific protocol was agreed
      * upon during the handshake. This can happen either because the client did not request any protocol, or because 
      * none of the requested protocols were accepted by the server.
      * 


### PR DESCRIPTION
- Added documentation regarding StompHeader property delegates.
- Changed SubscriptionHeader so it is always in a consistent state when constructed through the secondary constructor. This assures that the header will have an id when constructed this way. This eliminates the need to check and correct during subscribe.