### PR TITLE
[ktor] Fix missing synthetic Close frame on native CIO engine

### DIFF
--- a/krossbow-websocket-ktor/src/commonMain/kotlin/org/hildan/krossbow/websocket/ktor/KtorWebSocketClient.kt
+++ b/krossbow-websocket-ktor/src/commonMain/kotlin/org/hildan/krossbow/websocket/ktor/KtorWebSocketClient.kt
@@ -10,6 +10,7 @@ import io.ktor.websocket.*
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.selects.*
 import kotlinx.io.bytestring.*
 import kotlinx.io.bytestring.unsafe.*
 import org.hildan.krossbow.io.*
@@ -73,21 +74,63 @@ private class KtorWebSocketConnectionAdapter(
                     emittedCloseFrame.getAndSet(true)
                 }
             }
-            .onCompletion { error ->
-                // Ktor just closes the channel without sending the close frame, so we build it ourselves here.
+            .onCompletion { cause ->
+                // Ktor just closes the incoming channel without sending the close frame, so we build it ourselves.
+                // We can only emit from onCompletion when the upstream completed normally (cause == null): when it
+                // failed (e.g. the CIO engine cancels the incoming channel on close), onCompletion runs its action on
+                // a collector that re-throws the upstream exception on emit, so the Close frame is instead emitted from
+                // catch below.
                 // Clients could collect the flow multiple times, which calls onCompletion each time, but we only want
-                // to emit the Close frame once, as if it were in the channel like the other frames.
-                if (error == null && !emittedCloseFrame.getAndSet(true)) {
-                    buildCloseFrame()?.let { emit(it) }
+                // to emit the Close frame once, as if it were in the channel like the other frames, hence the atomic.
+                if (cause == null) {
+                    val closeReason = awaitSessionCloseReasonOrJobEnd()
+                    if (closeReason != null && !emittedCloseFrame.getAndSet(true)) {
+                        emit(closeReason.toCloseFrame())
+                    }
                 }
             }
             .catch { th ->
-                throw WebSocketException("error in Ktor's websocket: $th", cause = th)
+                // Never swallow a genuine cancellation of the collecting coroutine.
+                currentCoroutineContext().ensureActive()
+                // Some engines (notably CIO on Kotlin/Native) cancel the incoming channel when the connection closes,
+                // which surfaces here as a CancellationException rather than a normal completion. If the session
+                // recorded a close reason, this is a normal close: emit our synthesized Close frame (once) and let the
+                // flow complete normally. Otherwise it's a genuine error and we wrap it.
+                val closeReason = awaitSessionCloseReasonOrJobEnd()
+                if (closeReason != null) {
+                    if (!emittedCloseFrame.getAndSet(true)) {
+                        emit(closeReason.toCloseFrame())
+                    }
+                } else {
+                    throw WebSocketException("error in Ktor's websocket: $th", cause = th)
+                }
             }
 
-    private suspend fun buildCloseFrame(): WebSocketFrame.Close? = wsSession.closeReason.await()?.let { reason ->
-        WebSocketFrame.Close(reason.code.toInt(), reason.message)
+    /**
+     * Awaits the session's [closeReason][DefaultClientWebSocketSession.closeReason] so we can build our artificial
+     * Close frame, but stops waiting as soon as the session's coroutine job completes.
+     *
+     * This is only called once the connection is actually ending (either the incoming channel completed normally, or
+     * it failed/was canceled), so the session job is guaranteed to complete and we never hang.
+     *
+     * We can't read the close reason eagerly without waiting, because the CIO engine completes it slightly *after* it
+     * closes the incoming channel, so a non-suspending read would race ahead of it and miss the Close frame. But we
+     * can't await it unconditionally either, because it sometimes never completes (again, notably in the CIO engine),
+     * which would hang the flow forever. Racing the await against the session job completion waits just long enough to
+     * catch the close reason without risking an infinite wait: the session job always completes once the connection is
+     * over, whereas the close reason alone may never do so.
+     */
+    private suspend fun awaitSessionCloseReasonOrJobEnd(): CloseReason? = select {
+        wsSession.closeReason.onAwait { it }
+        wsSession.coroutineContext.job.onJoin { wsSession.closeReason.getOrNull() }
     }
+
+    /**
+     * Gets this [Deferred]'s value if it has already completed, or `null` otherwise (never wait).
+     */
+    private suspend fun <T> Deferred<T>.getOrNull(): T? = if (isCompleted) await() else null
+
+    private fun CloseReason.toCloseFrame(): WebSocketFrame.Close = WebSocketFrame.Close(code.toInt(), message)
 
     override suspend fun sendText(frameText: String) {
         wsSession.outgoing.send(Frame.Text(frameText))


### PR DESCRIPTION
The CIO engine on Kotlin/Native cancels the incoming frames channel when
the connection closes, so receiveAsFlow() surfaces a CancellationException
("Channel was cancelled") instead of completing normally. Our synthetic
Close frame emits from onCompletion only on normal upstream completion
(cause == null), so the cancellation reaches the catch operator and is
wrapped in a WebSocketException, breaking the echoText and echoBinary
tests on linuxX64.

We can't change onCompletion to handle non-null causes, because it runs
its action on a collector that re-throws the upstream exception on emit
whenever the upstream failed. So removing the cause==null chech would
result in a re-throw and the Close frame would still not reach the caller
anyway.

With this commit, we emit the synthetic Close frame from the catch
operator (which can emit recovery values) when the session recorded a
close reason, and complete the flow normally.

To handle the CIO timing where closeReason is completed slightly after the
incoming channel is torn down, awaitSessionCloseReason() races closeReason
against the session job completion, so it waits just long enough to catch the
reason without risking the hang that made us avoid awaiting it before.