### PR TITLE
Properly close websocket on invalid CONNECTED frame (invalid heart-beats)

### DIFF
--- a/krossbow-stomp-core/src/commonMain/kotlin/org/hildan/krossbow/stomp/StompWsExtensions.kt
+++ b/krossbow-stomp-core/src/commonMain/kotlin/org/hildan/krossbow/stomp/StompWsExtensions.kt
@@ -82,10 +82,20 @@ private suspend fun WebSocketConnection.stomp(
         // this cancellation comes from the outside, we should not wrap this exception
         throw e
     } catch (e: ConnectionTimeout) {
-        stompSocket.close(e)
+        try {
+            stompSocket.close(e)
+        } catch (closeException: Exception) {
+            e.addSuppressed(closeException)
+        }
         throw e
     } catch (e: Exception) {
-        throw StompConnectionException(headers.host, cause = e)
+        throw StompConnectionException(headers.host, cause = e).also {
+            try {
+                stompSocket.close(e)
+            } catch (closeException: Exception) {
+                it.addSuppressed(closeException)
+            }
+        }
     }
 }
 

--- a/krossbow-stomp-core/src/commonTest/kotlin/org/hildan/krossbow/stomp/StompClientTest.kt
+++ b/krossbow-stomp-core/src/commonTest/kotlin/org/hildan/krossbow/stomp/StompClientTest.kt
@@ -346,7 +346,7 @@ class StompClientTest {
     }
 
     @Test
-    fun connect_shouldNotLeakWebSocketConnectionIfCancelled() = runTest {
+    fun connect_shouldNotLeakWebSocketConnection_ifCancelled() = runTest {
         val wsClient = WebSocketClientMock()
         val stompClient = StompClient(wsClient)
 
@@ -359,6 +359,27 @@ class StompClientTest {
         // simulates the cancellation of the connect() call during the STOMP connect handshake
         connectJob.cancel()
         wsSession.expectClose()
+    }
+
+    @Test
+    fun connect_shouldNotLeakWebSocketConnection_ifReceivesInvalidHeartBeat() = runTest {
+        val wsClient = WebSocketClientMock()
+        val stompClient = StompClient(wsClient) {
+            // necessary so runTest knows to wait for the session's coroutines to progress
+            defaultSessionCoroutineContext = testScheduler // retrieves the test dispatcher
+        }
+        val deferredConnectionException = async {
+            assertFailsWith<StompConnectionException> {
+                stompClient.connect("dummy URL")
+            }
+        }
+
+        val wsSession = wsClient.awaitConnectAndSimulateSuccess()
+        wsSession.awaitConnectFrameAndSimulateCompletion()
+        // a valid frame with invalid heart beat header
+        wsSession.simulateTextFrameReceived("CONNECTED\nversion:1.2\nheart-beat:notANumber,0\n\n\u0000")
+        deferredConnectionException.await()
+        assertTrue(wsSession.closed, "web socket should be closed on heart-beat negotiation failure")
     }
 
     @Test


### PR DESCRIPTION
Resolves: https://github.com/joffrey-bion/krossbow/issues/764